### PR TITLE
Change Function Definition To Limit Scope

### DIFF
--- a/shell-mommy.sh
+++ b/shell-mommy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # sudofox/shell-mommy.sh
 
-mommy() {
+mommy() (
   MOMMY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
   # SHELL_MOMMYS_LITTLE - what to call you~ (default: "girl")
@@ -150,4 +150,4 @@ mommy() {
   # TODO: add a way to check if we're running from PROMPT_COMMAND to use the previous exit code instead of doing things this way
   eval "$@" && success || failure
   return $?
-}
+)


### PR DESCRIPTION
This is *probably* the tiniest pull request I've ever made, but I felt it was important.

Currently, Shell Mommy doesn't do a very good job keeping your variables and functions too tidy, things like `success()` and `failure()` remain defined in the main shell once `mommy()` has been called once... additionally, several variables such as `$DEF_WORDS_LITTLE` and `$DEF_WORDS_ROLES` also remain defined as well...

Since Mommy doesn't really *alter* anything outside of her scope, she can help you keep your ~~room~~ *shell* clean by working in a subshell instead.

Yes, this PR changes just two characters, but they are two characters of great power :3