### PR TITLE
made it so that a failure message isn't shown on intentional interrupts i.e. Ctrl+C or exit code 130

### DIFF
--- a/shell-mommy.sh
+++ b/shell-mommy.sh
@@ -139,7 +139,7 @@ mommy() {
   }
   failure() {
     local rc=$?
-    if [ $rc -eq 130 ]
+    if [[ $rc -eq 130 ]]
     then
         return 0
     fi

--- a/shell-mommy.sh
+++ b/shell-mommy.sh
@@ -139,6 +139,10 @@ mommy() {
   }
   failure() {
     local rc=$?
+    if [ $rc -eq 130 ]
+    then
+        return 0
+    fi
     (
       local response="$(pick_response "negative")"
       sub_terms "$response" >&2


### PR DESCRIPTION
A quick fix for issue https://github.com/sudofox/shell-mommy/issues/15

I cancelled a git push and got a message from shell-mommy, decided to open up an issue, already saw an existing issue and decided to write up a quick fix instead.